### PR TITLE
Add renaming of FMU in/out variables in type declaration

### DIFF
--- a/src/main/antlr/While.g4
+++ b/src/main/antlr/While.g4
@@ -88,6 +88,7 @@ INFLUXMODE : 'INFLUXDB';
 // changing the syntax here
 IN : 'in';
 OUT : 'out';
+AS : 'as';
 
 //Names etc.
 fragment DIG : [0-9];
@@ -176,7 +177,7 @@ type : NAME                                                    #simple_type
 typelist : type (COMMA type)*;
 param : type NAME;
 paramList : param (COMMA param)*;
-fmuparam : direction=(IN | OUT) param;
+fmuparam : direction=(IN | OUT) param (AS smol_name=NAME)?;
 fmuParamList : fmuparam (COMMA fmuparam)*;
 fieldDecl : (infer=INFERPRIVATE)? (visibility=visibilitymodifier)? (domain=DOMAIN)? type NAME;
 fieldDeclList : fieldDecl (COMMA fieldDecl)*;

--- a/src/main/kotlin/no/uio/microobject/runtime/Interpreter.kt
+++ b/src/main/kotlin/no/uio/microobject/runtime/Interpreter.kt
@@ -508,6 +508,8 @@ class Interpreter(
                 return Pair(null, emptyList())
             }
             is SimulationStmt -> {
+                val inVars = (stmt.declares as? SimulatorType)?.inVar
+                val outVars = (stmt.declares as? SimulatorType)?.outVar
                 val simObj = SimulatorObject(stmt.path, stmt.params.associate {
                     Pair(
                         it.name, eval(
@@ -517,7 +519,7 @@ class Interpreter(
                             obj
                         )
                     )
-                }.toMutableMap())
+                }.toMutableMap(), inVars, outVars)
                 val name = Names.getObjName("CoSimulation")
                 simMemory[name] = simObj
                 return Pair(StackEntry(AssignStmt(stmt.target, name, declares = stmt.declares), stackMemory, obj, id), listOf())


### PR DESCRIPTION
- We want to use an FMU but use different names for in- and out-variables.
- `Cont[in Int x as meaningful_name] sim = simulate(...);`
- Todo: testing, documentation, unit tests

Compiles but needs testing etc.:
- Test if it works
- Type-check against duplicate names (x as foo, y as foo)