### PR TITLE
Issue #36 (DOUBLETYPE error) fix

### DIFF
--- a/src/main/kotlin/no/uio/microobject/ast/stmt/ConstructStmt.kt
+++ b/src/main/kotlin/no/uio/microobject/ast/stmt/ConstructStmt.kt
@@ -67,6 +67,10 @@ data class ConstructStmt(val target : Location, val query: Expression, val param
                             newObjMemory[f.name] = LiteralExpr(extractedName.split("^^")[0], INTTYPE)
                         else if (f.type == INTTYPE && (extractedName.matches("\\d+".toRegex()) || extractedName.matches("\\d+\\^\\^http://www.w3.org/2001/XMLSchema#integer".toRegex())))
                             newObjMemory[f.name] = LiteralExpr(extractedName.split("^^")[0], INTTYPE)
+                        else if (f.type == DOUBLETYPE && r.getLiteral(f.name).asNode().literalDatatype == XSDDatatype.XSDdouble)
+                            newObjMemory[f.name] = LiteralExpr(extractedName.split("^^")[0], DOUBLETYPE)
+                        else if (f.type == DOUBLETYPE && (extractedName.matches("\\d+".toRegex()) || extractedName.matches("\\d+\\^\\^http://www.w3.org/2001/XMLSchema#double".toRegex())))
+                            newObjMemory[f.name] = LiteralExpr(extractedName.split("^^")[0], DOUBLETYPE)
                         else if(f.type == STRINGTYPE)
                             newObjMemory[f.name] = LiteralExpr("\""+extractedName+"\"", f.type)
                         else

--- a/src/test/kotlin/no/uio/microobject/test/runtime/Interpreter.kt
+++ b/src/test/kotlin/no/uio/microobject/test/runtime/Interpreter.kt
@@ -1,0 +1,21 @@
+package no.uio.microobject.test.runtime
+
+import io.kotest.matchers.shouldBe
+import no.uio.microobject.ast.expr.LiteralExpr
+import no.uio.microobject.test.MicroObjectTest
+import no.uio.microobject.type.*
+
+class Interpreter : MicroObjectTest() {
+    private fun evalTest() {
+        val (interpreter,_) = initInterpreter("persons", StringLoad.RES)
+        val expr = LiteralExpr("50.0")
+        val result = interpreter.eval(expr, interpreter.stack.peek())
+        result shouldBe LiteralExpr("50.0")
+    }
+
+    init {
+        "eval" {
+            evalTest()
+        }
+    }
+}


### PR DESCRIPTION
To ensure double are treated properly in both decoding and encoding, I added the match for the double type on the ConstructStmt for the Interpreter.