### PR TITLE
Add prefixes to prefixMap for the interpreter

### DIFF
--- a/src/main/kotlin/no/uio/microobject/main/MainKt.kt
+++ b/src/main/kotlin/no/uio/microobject/main/MainKt.kt
@@ -50,6 +50,11 @@ data class Settings(var verbose : Boolean,      //Verbosity
         return prefixMapCache as HashMap<String, String>
     }
 
+    fun addPrefixes(prefixes: HashMap<String, String>){
+        prefixMapCache = null
+        extraPrefixes.putAll(prefixes)
+    }
+
     fun replaceKnownPrefixes(string: String) : String{
         var res = string.replace("domain:", "$domainPrefix:")
             .replace("prog:", "$progPrefix:")

--- a/src/test/kotlin/no/uio/microobject/test/basic/ExtraPrefixTest.kt
+++ b/src/test/kotlin/no/uio/microobject/test/basic/ExtraPrefixTest.kt
@@ -1,0 +1,17 @@
+package no.uio.microobject.test.basic
+
+import io.kotest.matchers.shouldBe
+import no.uio.microobject.test.MicroObjectTest
+
+class ExtraPrefixTest: MicroObjectTest() {
+    fun prefixTest() {
+        val (interpreter,_) = initInterpreter("persons", StringLoad.RES)
+
+        interpreter.settings.prefixMap().containsKey("ast") shouldBe false
+        interpreter.settings.addPrefixes(hashMapOf("ast" to "http://www.smolang.org/ast#"))
+        interpreter.settings.prefixMap().containsKey("ast") shouldBe true
+    }
+    init {
+        prefixTest()
+    }
+}


### PR DESCRIPTION
Added feature to add extra prefixes at any time instead of only at creation of settings of interpreter